### PR TITLE
Configure expo-updates for EAS Update

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install expo-updates (if needed)
         run: npx expo install expo-updates
 
+      - name: Prebuild
+        run: npx expo prebuild --non-interactive
+
       - name: Publish to Expo
         run: npx eas update --branch preview --non-interactive
         env:

--- a/app.json
+++ b/app.json
@@ -7,6 +7,10 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,
+    "updates": {
+      "enabled": true,
+      "fallbackToCacheTimeout": 0
+    },
     "splash": {
       "image": ".assets/hydcom1-splash.png",
       "resizeMode": "contain",
@@ -40,6 +44,7 @@
     },
     "plugins": [
       "expo-sqlite",
+      "expo-updates",
       [
         "expo-location",
         {


### PR DESCRIPTION
## Summary
- enable `expo-updates` plugin and configuration
- add prebuild step to EAS Update workflow

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68635b68ea988332bac86c4a4fa5fd23