### PR TITLE
Fix Expo prebuild path

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -27,7 +27,7 @@ jobs:
         run: npx expo install expo-updates
 
       - name: Prebuild
-        run: npx expo prebuild --non-interactive
+        run: CI=1 npx expo prebuild
 
       - name: Publish to Expo
         run: npx eas update --branch preview --non-interactive

--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
       "fallbackToCacheTimeout": 0
     },
     "splash": {
-      "image": ".assets/hydcom1-splash.png",
+      "image": "./assets/hydcom1-splash.png",
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },


### PR DESCRIPTION
## Summary
- fix path to splash image in `app.json`
- run `expo prebuild` with CI mode in GitHub Actions

## Testing
- `npm ci`
- `CI=1 npx expo prebuild`

------
https://chatgpt.com/codex/tasks/task_e_68635d8a53008332a80f7401e4943fe2