### PR TITLE
Fix Expo update step

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -30,6 +30,6 @@ jobs:
         run: CI=1 npx expo prebuild
 
       - name: Publish to Expo
-        run: npx eas update --branch preview --non-interactive
+        run: npx eas update --auto --branch preview --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}


### PR DESCRIPTION
## Summary
- add `--auto` flag to EAS update step to meet non-interactive requirements

## Testing
- `npm ci`
- `npm install -g expo-cli eas-cli`
- `npx expo install expo-updates`
- `CI=1 npx expo prebuild`
- `npx eas update --branch preview --non-interactive` *(fails: `--branch and --message, or --channel and --message are required when updating in non-interactive mode unless --auto is specified`)*

------
https://chatgpt.com/codex/tasks/task_e_6863612ee2648332a5e34d71f596eff5