### PR TITLE
Fix Node version in workflow

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci || npm install


### PR DESCRIPTION
## Summary
- use Node 18 instead of 20 in the EAS update workflow

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6863764ef1308332a13388c9a270b5dd