### PR TITLE
Add LocationMap component with map tiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-updates": "^0.20.0",
         "react": "19.0.0",
         "react-native": "0.79.3",
+        "react-native-maps": "^1.24.3",
         "react-native-svg": "15.11.2",
         "victory-native": "^41.17.4"
       },
@@ -2742,6 +2743,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -7771,6 +7778,28 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-maps": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.24.3.tgz",
+      "integrity": "sha512-cF5oTA8z24QqGIRFfDcsXLEs/gCd0RhaJ9KPv/2HiogKD5gpjh1naimZUJQ6IsEcUngSSk8iov6p2jd7dB+/bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.13"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
+        "react-native-web": ">= 0.11"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.3",
+    "react-native-maps": "^1.24.3",
     "react-native-svg": "15.11.2",
     "victory-native": "^41.17.4"
   },

--- a/src/components/LocationMap.js
+++ b/src/components/LocationMap.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import MapView, { Marker, UrlTile } from 'react-native-maps';
+
+const INITIAL_DELTA = 0.01; // roughly zoom level 15
+
+const LocationMap = ({ location }) => {
+  if (!location) {
+    return <Text style={styles.loadingText}>Waiting for location...</Text>;
+  }
+
+  const { latitude, longitude } = location.coords ? location.coords : location;
+  const [region, setRegion] = useState({
+    latitude,
+    longitude,
+    latitudeDelta: INITIAL_DELTA,
+    longitudeDelta: INITIAL_DELTA,
+  });
+
+  useEffect(() => {
+    setRegion({
+      latitude,
+      longitude,
+      latitudeDelta: INITIAL_DELTA,
+      longitudeDelta: INITIAL_DELTA,
+    });
+  }, [latitude, longitude]);
+
+  return (
+    <View style={styles.container}>
+      <MapView
+        style={styles.map}
+        region={region}
+        onRegionChangeComplete={setRegion}
+      >
+        <UrlTile urlTemplate="https://tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <Marker coordinate={{ latitude, longitude }} />
+      </MapView>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: 200,
+    borderRadius: 10,
+    overflow: 'hidden',
+    marginVertical: 10,
+  },
+  map: {
+    flex: 1,
+  },
+  loadingText: {
+    textAlign: 'center',
+    padding: 20,
+  },
+});
+
+export default LocationMap;


### PR DESCRIPTION
## Summary
- add OpenStreetMap-based `LocationMap` component using `react-native-maps`
- install `react-native-maps` dependency

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863acdfa6dc8332b4ce0c2f434c146c