### PR TITLE
Add SunTrackPlot component with orientation hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-native": "0.79.3",
         "react-native-maps": "^1.24.3",
         "react-native-svg": "15.11.2",
+        "suncalc": "^1.9.0",
         "victory-native": "^41.17.4"
       },
       "devDependencies": {
@@ -8731,6 +8732,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/suncalc": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/suncalc/-/suncalc-1.9.0.tgz",
+      "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "expo": "~53.0.11",
-    "expo-updates": "^0.20.0",
     "expo-barcode-scanner": "^13.0.1",
     "expo-camera": "~16.1.8",
     "expo-file-system": "~18.1.10",
@@ -18,10 +17,12 @@
     "expo-media-library": "~17.1.7",
     "expo-sqlite": "~15.2.12",
     "expo-status-bar": "~2.2.3",
+    "expo-updates": "^0.20.0",
     "react": "19.0.0",
     "react-native": "0.79.3",
     "react-native-maps": "^1.24.3",
     "react-native-svg": "15.11.2",
+    "suncalc": "^1.9.0",
     "victory-native": "^41.17.4"
   },
   "devDependencies": {

--- a/src/components/SunTrackPlot.js
+++ b/src/components/SunTrackPlot.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import Svg, { Circle, Path, G, Line } from 'react-native-svg';
+import { styles } from '../styles/AppStyles';
+import useSunTracks from '../hooks/useSunTracks';
+import useDeviceOrientation from '../hooks/useDeviceOrientation';
+
+const polarToCartesian = (radius, azimuth, elevation) => {
+  const r = radius * (1 - Math.max(elevation, -90) / 90);
+  const angle = (azimuth - 90) * Math.PI / 180; // 0 deg at north
+  return {
+    x: radius + r * Math.cos(angle),
+    y: radius + r * Math.sin(angle),
+  };
+};
+
+const buildPath = (radius, points) => {
+  if (!points || points.length === 0) return '';
+  return points
+    .map((p, i) => {
+      const { x, y } = polarToCartesian(radius, p.azimuth, p.elevation);
+      return `${i === 0 ? 'M' : 'L'}${x} ${y}`;
+    })
+    .join(' ');
+};
+
+const SunTrackPlot = ({ size = 220 }) => {
+  const { tracks, currentSun, location } = useSunTracks();
+  const { heading, pitch, roll } = useDeviceOrientation();
+  const radius = size / 2;
+
+  return (
+    <View style={[styles.section, { alignItems: 'center' }]}>
+      <Text style={styles.sectionTitle}>Sun Tracks</Text>
+      {!location && <Text>Getting GPS...</Text>}
+      {location && (
+        <Svg width={size} height={size}>
+          <G rotation={-heading} origin={`${radius}, ${radius}`}>
+            {/* Horizon and guide lines */}
+            <Circle cx={radius} cy={radius} r={radius} stroke="#ccc" strokeWidth={1} fill="none" />
+            <Circle cx={radius} cy={radius} r={radius / 2} stroke="#eee" strokeWidth={1} fill="none" />
+            <Line x1={radius} y1={0} x2={radius} y2={size} stroke="#ddd" />
+            <Line x1={0} y1={radius} x2={size} y2={radius} stroke="#ddd" />
+            {/* Sun tracks */}
+            <Path d={buildPath(radius, tracks.summer)} stroke="#ff8c00" strokeWidth={2} fill="none" />
+            <Path d={buildPath(radius, tracks.winter)} stroke="#1e90ff" strokeWidth={2} fill="none" />
+            <Path d={buildPath(radius, tracks.current)} stroke="#2ecc71" strokeWidth={2} fill="none" />
+            {currentSun && (
+              <>
+                <Circle
+                  cx={polarToCartesian(radius, currentSun.azimuth, currentSun.elevation).x}
+                  cy={polarToCartesian(radius, currentSun.azimuth, currentSun.elevation).y}
+                  r={4}
+                  fill="yellow"
+                  stroke="black"
+                />
+                <Text
+                  style={{ position: 'absolute', left: radius - 15, top: radius - 10, fontSize: 12 }}
+                >
+                  ☀
+                </Text>
+              </>
+            )}
+          </G>
+        </Svg>
+      )}
+      <Text style={{ marginTop: 5, fontSize: 12 }}>
+        Pitch: {pitch.toFixed(1)}° Roll: {roll.toFixed(1)}°
+      </Text>
+    </View>
+  );
+};
+
+export default SunTrackPlot;

--- a/src/hooks/useDeviceOrientation.js
+++ b/src/hooks/useDeviceOrientation.js
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import * as Location from 'expo-location';
+import { DeviceMotion } from 'expo-sensors';
+
+const radToDeg = (rad) => rad * (180 / Math.PI);
+
+const useDeviceOrientation = () => {
+  const [heading, setHeading] = useState(0);
+  const [pitch, setPitch] = useState(0);
+  const [roll, setRoll] = useState(0);
+
+  useEffect(() => {
+    let headingSub = null;
+    let motionSub = null;
+    let isMounted = true;
+
+    const start = async () => {
+      try {
+        // Get heading updates
+        headingSub = await Location.watchHeadingAsync((data) => {
+          const current = data.trueHeading !== -1 ? data.trueHeading : data.magHeading;
+          if (current !== -1 && isMounted) {
+            setHeading(current);
+          }
+        });
+      } catch (e) {
+        // Ignore heading if unavailable
+      }
+
+      // Device motion for tilt
+      DeviceMotion.setUpdateInterval(200);
+      motionSub = DeviceMotion.addListener(({ rotation }) => {
+        if (!rotation) return;
+        if (isMounted) {
+          setPitch(radToDeg(rotation.beta));
+          setRoll(radToDeg(rotation.gamma));
+        }
+      });
+    };
+
+    start();
+
+    return () => {
+      isMounted = false;
+      if (headingSub) headingSub.remove();
+      if (motionSub) motionSub.remove();
+    };
+  }, []);
+
+  return { heading, pitch, roll };
+};
+
+export default useDeviceOrientation;

--- a/src/hooks/useSunTracks.js
+++ b/src/hooks/useSunTracks.js
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react';
+import * as Location from 'expo-location';
+import SunCalc from 'suncalc';
+
+const deg = (rad) => rad * (180 / Math.PI);
+
+const getTrack = (date, lat, lon) => {
+  const hours = Array.from({ length: 25 }, (_, i) => i);
+  return hours.map((h) => {
+    const d = new Date(date);
+    d.setHours(h, 0, 0, 0);
+    const { azimuth, altitude } = SunCalc.getPosition(d, lat, lon);
+    return {
+      azimuth: (deg(azimuth) + 180) % 360, // convert to 0=N
+      elevation: deg(altitude),
+    };
+  });
+};
+
+const useSunTracks = () => {
+  const [location, setLocation] = useState(null);
+  const [tracks, setTracks] = useState({ current: [], summer: [], winter: [] });
+  const [currentSun, setCurrentSun] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const getLoc = async () => {
+      try {
+        const { status } = await Location.requestForegroundPermissionsAsync();
+        if (status !== 'granted') return;
+        const loc = await Location.getCurrentPositionAsync({});
+        if (!cancelled) {
+          setLocation({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
+        }
+      } catch (e) {}
+    };
+    getLoc();
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (!location) return;
+    const { latitude, longitude } = location;
+    const now = new Date();
+    const year = now.getFullYear();
+    const summer = new Date(year, 11, 21); // Dec 21
+    const winter = new Date(year, 5, 21);  // Jun 21
+
+    setTracks({
+      current: getTrack(now, latitude, longitude),
+      summer: getTrack(summer, latitude, longitude),
+      winter: getTrack(winter, latitude, longitude),
+    });
+
+    const posNow = SunCalc.getPosition(now, latitude, longitude);
+    setCurrentSun({
+      azimuth: (deg(posNow.azimuth) + 180) % 360,
+      elevation: deg(posNow.altitude),
+    });
+  }, [location]);
+
+  return { tracks, currentSun, location };
+};
+
+export default useSunTracks;


### PR DESCRIPTION
## Summary
- add SunTrackPlot component that draws a hemispherical sun path diagram
- compute sun paths for current date and solstices using new `useSunTracks` hook
- track device heading and tilt with new `useDeviceOrientation` hook
- install `suncalc` dependency for solar calculations

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864caaa39ac8332aee1404e5235afa5