### PR TITLE
Fix Expo boot issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,11 @@
         "expo-media-library": "~17.1.7",
         "expo-sqlite": "~15.2.12",
         "expo-status-bar": "~2.2.3",
+        "expo-sensors": "~14.1.4",
         "expo-updates": "^0.20.0",
         "react": "19.0.0",
         "react-native": "0.79.3",
-        "react-native-maps": "^1.24.3",
+        "react-native-maps": "1.20.1",
         "react-native-svg": "15.11.2",
         "suncalc": "^1.9.0",
         "victory-native": "^41.17.4"
@@ -4886,6 +4887,16 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-sensors": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/expo-sensors/-/expo-sensors-14.1.4.tgz",
+      "integrity": "sha512-Jj2EajLucUMRB54XXJsL59ObIdWhvBxLrBNvXiAWepKvbl34uSt+KgwxG1hnIgVcRfK2JkQA1nqVJ4Pu11Hthg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-structured-headers": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-3.4.0.tgz",
@@ -7782,9 +7793,9 @@
       }
     },
     "node_modules/react-native-maps": {
-      "version": "1.24.3",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.24.3.tgz",
-      "integrity": "sha512-cF5oTA8z24QqGIRFfDcsXLEs/gCd0RhaJ9KPv/2HiogKD5gpjh1naimZUJQ6IsEcUngSSk8iov6p2jd7dB+/bQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
+      "integrity": "sha512-sNE0atvfFIpcCBg/EaVP1cGd/OmNNaTa/XmATxvGxw/SC1F0QjOi7ZhxB8CPzCcUMRg0IlxO2bqs3OGGAaHo9A==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.13"

--- a/package.json
+++ b/package.json
@@ -17,10 +17,11 @@
     "expo-media-library": "~17.1.7",
     "expo-sqlite": "~15.2.12",
     "expo-status-bar": "~2.2.3",
+    "expo-sensors": "~14.1.4",
     "expo-updates": "^0.20.0",
     "react": "19.0.0",
     "react-native": "0.79.3",
-    "react-native-maps": "^1.24.3",
+    "react-native-maps": "1.20.1",
     "react-native-svg": "15.11.2",
     "suncalc": "^1.9.0",
     "victory-native": "^41.17.4"


### PR DESCRIPTION
## Summary
- use Expo-compatible react-native-maps version
- include expo-sensors dependency

## Testing
- `node --check App.js`


------
https://chatgpt.com/codex/tasks/task_e_686512202de083328c3447e76da2520a