### PR TITLE
Fix blank web screens and add 3D sun track

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-native-maps": "1.20.1",
         "react-native-svg": "15.11.2",
         "suncalc": "^1.9.0",
+        "victory": "^37.3.6",
         "victory-native": "^41.17.4"
       },
       "devDependencies": {
@@ -2717,6 +2718,69 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -4057,6 +4121,12 @@
         "d3-selection": "2 - 3"
       }
     },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/d3-zoom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
@@ -4127,6 +4197,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "license": "ISC"
+    },
+    "node_modules/delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "^4.0.0"
       }
     },
     "node_modules/depd": {
@@ -5030,18 +5115,6 @@
       },
       "bin": {
         "fingerprint": "bin/cli.js"
-      }
-    },
-    "node_modules/expo-updates/node_modules/@expo/json-file": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-8.3.3.tgz",
-      "integrity": "sha512-eZ5dld9AD0PrVRiIWpRkm5aIoWBw3kAyd8VkuWEy92sEthBKDDDHAnK2a0dw0Eil6j7rK7lS/Qaq/Zzngv2h5A==",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "json5": "^2.2.2",
-        "write-file-atomic": "^2.3.0"
       }
     },
     "node_modules/expo-updates/node_modules/@expo/plist": {
@@ -6019,6 +6092,12 @@
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6331,6 +6410,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -9215,6 +9300,341 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/victory": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-37.3.6.tgz",
+      "integrity": "sha512-CZ1vjvra0R1U3T2dMI4EsjI8Ng+JmQ2ox/EweSzjkTnHfW/Vn5ylryadawDiYjDMcBvABjO3uODsIlSEm4d/Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "victory-area": "37.3.6",
+        "victory-axis": "37.3.6",
+        "victory-bar": "37.3.6",
+        "victory-box-plot": "37.3.6",
+        "victory-brush-container": "37.3.6",
+        "victory-brush-line": "37.3.6",
+        "victory-candlestick": "37.3.6",
+        "victory-canvas": "37.3.6",
+        "victory-chart": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-create-container": "37.3.6",
+        "victory-cursor-container": "37.3.6",
+        "victory-errorbar": "37.3.6",
+        "victory-group": "37.3.6",
+        "victory-histogram": "37.3.6",
+        "victory-legend": "37.3.6",
+        "victory-line": "37.3.6",
+        "victory-pie": "37.3.6",
+        "victory-polar-axis": "37.3.6",
+        "victory-scatter": "37.3.6",
+        "victory-selection-container": "37.3.6",
+        "victory-shared-events": "37.3.6",
+        "victory-stack": "37.3.6",
+        "victory-tooltip": "37.3.6",
+        "victory-voronoi": "37.3.6",
+        "victory-voronoi-container": "37.3.6",
+        "victory-zoom-container": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.6.tgz",
+      "integrity": "sha512-wVC8LKrZJLiSySNuJLRCB449qZTsPiRyzLlNoJwe21y+XA/a2HJbmJSeywmo8P153aX8viKe1H8ygDsTFXQhHw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-axis": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.6.tgz",
+      "integrity": "sha512-Vi0dZvgmXmnCdoqc49WckeG5cMXnl7FTtqVhXu9JweA9cgCnkZabBd5mRvAjblb3Lo4j0HZCSPKHYWUPW70qZg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-bar": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.6.tgz",
+      "integrity": "sha512-jdATFRWL1LUW/yEpKWx/aId2BiU2o1pPF9+Kh1TFISBduJoI4ZqvZD90H1QK4f/z50PikqiqiDECaKoKM1jfOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.6.tgz",
+      "integrity": "sha512-GOucnD63h14ScBuISC/nd1GBTEx6gIZfLE+0P0gyeH1poBKq0trTTvpQDvAMuGR8zICfEETG3ltmUMCwRrFyUg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-37.3.6.tgz",
+      "integrity": "sha512-LfZ2CgX1cYAqCtYxcSB68OfZS2v0T2VLXoEArd0lCXfRBY1Gya7GacCUcuo7GoK9XOXeslx7S/U95aVutt1VLg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-37.3.6.tgz",
+      "integrity": "sha512-zsZJfF1fUj4F7mUoIMV+h73qoTClPA4bKM1terlYrDBD8l/c/f0KBbEotu3E1X+n4QMmDRruswaB/YUdqK5QLA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-37.3.6.tgz",
+      "integrity": "sha512-h/mOmkCrsWrirn4dFnpLxJPXpxT+uHxuYxnXGrAyH+YUOrVj3iKaDJlEiVlz5vy30syE5j5hzTQCMsZ/hzHNdg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-canvas": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-37.3.6.tgz",
+      "integrity": "sha512-1CD4S0uZ92sUGGSIEQferEfSqd/z9EXw9G6zkzPIoJeTKFshpfqCjUkNRx9Iu9Upxt3fUpId8Qwl1YfchmbrFg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-bar": "37.3.6",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-chart": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.6.tgz",
+      "integrity": "sha512-IkPo/W4AJ7bPu902TGER09OseR9ODm+FQAKfOBw4JsdEhZZ7BiG9zgd/25+x0r5EsTLu81CYGQVkBa+ZazcOlA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-axis": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-polar-axis": "37.3.6",
+        "victory-shared-events": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-core": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.6.tgz",
+      "integrity": "sha512-aFgO6KokxPbUCPznZP5UPhOdI22pMuwDXKDt6eoQOnkVim66Ia+K95TQar2nwVKGYV5j26aKVf/n9blwphGJRw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "react-fast-compare": "^3.2.0",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-create-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.6.tgz",
+      "integrity": "sha512-Uf5bFQvqUsXCjqpvBW4LhrdrHkM6dBqxYgub6FCsBb86f84xZQ3vY7jFkg/JfvF0oGKMoWXYYrYLC1sk+fcWVA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-cursor-container": "37.3.6",
+        "victory-selection-container": "37.3.6",
+        "victory-voronoi-container": "37.3.6",
+        "victory-zoom-container": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-cursor-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.6.tgz",
+      "integrity": "sha512-+Oiw57d5nE+iq8As8RvepknzmNtKq1Gsc50u1X3IRd4jXtX8zqZrgXGlVZ+BP/tkLsWnGYVjKulwKBf2oaEUuw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-37.3.6.tgz",
+      "integrity": "sha512-WGAv/qizOlfmwKv+Yfxr4q6pDgTfloNQwi3Z3M0h8povjMZt74tHYkvi/TASSRYr3zv5kjUqUJ28qAyGMWwryQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-group": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.6.tgz",
+      "integrity": "sha512-kgy/Azl5BxwlJAV0KDPGypv35TMrOD1J2ZxnJW2Wyyq+e8i0GGBIv5MoBzou64BRsDlS9V0CYRIjnkHgrBpB5w==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6",
+        "victory-shared-events": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-37.3.6.tgz",
+      "integrity": "sha512-K4d43MpXHYnGCLEMzfRpJ+lCRRDKALPi/juxfMGVzBPzSMgjC8h9x6hKdxaejiTd/E04UdzNO7J24plL3Uz8rA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-bar": "37.3.6",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-legend": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.6.tgz",
+      "integrity": "sha512-vRRrhj3/ENqKVLdaBMzEmR83N6BOjox1bthYT1eJjN2H5SIK35bxn30IkiV/Pz3y627EqZe4TAWaxc0jiJlCiA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-line": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.6.tgz",
+      "integrity": "sha512-Ke817uf/qFbN9jU7Dba7CrcHXYO5wAZuKKnyeHJmLDeQeFST0773xejnIuC+dBgZipjFr4KIbSd+VcUafFNE1g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
     "node_modules/victory-native": {
       "version": "41.17.4",
       "resolved": "https://registry.npmjs.org/victory-native/-/victory-native-41.17.4.tgz",
@@ -9233,6 +9653,197 @@
         "react-native": "*",
         "react-native-gesture-handler": ">=2.0.0",
         "react-native-reanimated": ">=3.0.0"
+      }
+    },
+    "node_modules/victory-pie": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.6.tgz",
+      "integrity": "sha512-tvdgAZ/HQWlo3KDDe0XAVbizHuaNMbgkkiF7zfA7Ww+3bHSs+0P9dsDtK2xP365D8gBCOv8pWmuzvKRhzNbqeA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6",
+        "victory-vendor": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-polar-axis": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-37.3.6.tgz",
+      "integrity": "sha512-RpFsCkzHezJq5P+C/wtVdjEHX25JIFsSgs6qYSnfr/hayaFbWgK5HhRFpriQm5hg61cx47WxAOLyHvzf0nasvw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-scatter": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.6.tgz",
+      "integrity": "sha512-fp95zMTPXgW1cmTowzDXhn+KxePMVDrzU0lotsHQMdBV7eB+ioXdu9hORlx4VHmMYg2ihsGwRTF+VAZ7rGxphA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-selection-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-37.3.6.tgz",
+      "integrity": "sha512-gd3qODDlBtLEJM7+2jCXk2YcLBUmIpYEEHswytMhwc6zihxXipGBUHRulhLj/I05mKay2gaOAg5ewiJHd4Awgw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-shared-events": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-37.3.6.tgz",
+      "integrity": "sha512-ygrbOtzLUTbtKebacZKyQRekhSAROnAvMkVI/PKsAGsz0ClY9P7qDEJG7eTUUygjO6ax0tI6WNE6JogQzeD1gw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-stack": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.6.tgz",
+      "integrity": "sha512-ldod04RdqGJGH5p5eWXCofdTkbhZqIp3iwW7NpxSbMDLs8zPQIVvDFVtuJgMwQiC5vnIpbhMmxVeFbr8m64ZKA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6",
+        "victory-shared-events": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-tooltip": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.6.tgz",
+      "integrity": "sha512-vqaJS9noauOqDDBBAV9Ln9duOY/i17h1DCfCPAqhwPFyvFbwKvAub9zPTeYWAm/14VvWX5O/0yekFCVbcC7hjg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-voronoi": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-37.3.6.tgz",
+      "integrity": "sha512-Q+1FWHp8IAbmDL9pGWS0y0N4Cb5qmD9OOgxoxCfIDsLlhGvd6LddhRoknWsN7WnreaK+XiwjSfQkdMTCZ4hdhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-voronoi": "^1.1.4",
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-voronoi-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.6.tgz",
+      "integrity": "sha512-qAAG0rMuK7A4EoJ4cyUk5wNdOW+HuCXNKPOko+hYK6wWOYXJvFhiglYyA85a695YyAXECc6JyJS/crm4IOEFag==",
+      "license": "MIT",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "37.3.6",
+        "victory-tooltip": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-zoom-container": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.6.tgz",
+      "integrity": "sha512-AGL+k20mI44OL5b0VgIxlmnNSefIoFmbbim5NraPmIxbtns9qQW/56ivIncJcYomBungIx99gUpsEpcQaMNHgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "37.3.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/vlq": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-native-maps": "1.20.1",
     "react-native-svg": "15.11.2",
     "suncalc": "^1.9.0",
+    "victory": "^37.3.6",
     "victory-native": "^41.17.4"
   },
   "devDependencies": {

--- a/src/components/CameraCapture.js
+++ b/src/components/CameraCapture.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Modal, View, StyleSheet, Button, Text } from 'react-native';
+import { Modal, View, StyleSheet, Button, Text, Platform } from 'react-native';
 import { Camera } from 'expo-camera';
 
 const CameraCapture = ({ visible, onClose, onPhoto }) => {
@@ -8,6 +8,11 @@ const CameraCapture = ({ visible, onClose, onPhoto }) => {
 
   useEffect(() => {
     (async () => {
+      if (Platform.OS === 'web') {
+        // Camera API not supported on web
+        setHasPermission(false);
+        return;
+      }
       const { status } = await Camera.requestCameraPermissionsAsync();
       setHasPermission(status === 'granted');
     })();
@@ -22,6 +27,17 @@ const CameraCapture = ({ visible, onClose, onPhoto }) => {
   };
 
   if (!visible) return null;
+
+  if (Platform.OS === 'web') {
+    return (
+      <Modal visible={visible} animationType="slide">
+        <View style={styles.center}>
+          <Text>Camera not supported on web</Text>
+          <Button title="Close" onPress={onClose} />
+        </View>
+      </Modal>
+    );
+  }
 
   if (hasPermission === null) {
     return (

--- a/src/components/CrossSectionChart.js
+++ b/src/components/CrossSectionChart.js
@@ -1,6 +1,16 @@
 import React from 'react';
-import { View, Text } from 'react-native';
-import { VictoryChart, VictoryLine, VictoryScatter, VictoryAxis, VictoryTheme, VictoryLabel } from 'victory-native';
+import { View, Text, Platform } from 'react-native';
+
+// Use web Victory package when running in a web environment
+const Victory = Platform.OS === 'web' ? require('victory') : require('victory-native');
+const {
+  VictoryChart,
+  VictoryLine,
+  VictoryScatter,
+  VictoryAxis,
+  VictoryTheme,
+  VictoryLabel,
+} = Victory;
 import { styles } from '../styles/AppStyles';
 
 const CrossSectionChart = ({ points = [] }) => {

--- a/src/components/SunTrackPlot.js
+++ b/src/components/SunTrackPlot.js
@@ -34,8 +34,17 @@ const SunTrackPlot = ({ size = 220 }) => {
       <Text style={styles.sectionTitle}>Sun Tracks</Text>
       {!location && <Text>Getting GPS...</Text>}
       {location && (
-        <Svg width={size} height={size}>
-          <G rotation={-heading} origin={`${radius}, ${radius}`}>
+        <View
+          style={{
+            transform: [
+              { perspective: 600 },
+              { rotateX: `${pitch}deg` },
+              { rotateY: `${roll}deg` },
+            ],
+          }}
+        >
+          <Svg width={size} height={size}>
+            <G rotation={-heading} origin={`${radius}, ${radius}`}>
             {/* Horizon and guide lines */}
             <Circle cx={radius} cy={radius} r={radius} stroke="#ccc" strokeWidth={1} fill="none" />
             <Circle cx={radius} cy={radius} r={radius / 2} stroke="#eee" strokeWidth={1} fill="none" />
@@ -63,6 +72,7 @@ const SunTrackPlot = ({ size = 220 }) => {
             )}
           </G>
         </Svg>
+        </View>
       )}
       <Text style={{ marginTop: 5, fontSize: 12 }}>
         Pitch: {pitch.toFixed(1)}° Roll: {roll.toFixed(1)}°


### PR DESCRIPTION
## Summary
- add `victory` dependency for web rendering
- allow `CrossSectionChart` to load Victory based on platform
- handle camera open on web with friendly message
- rotate sun track plot in 3D using device pitch/roll

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6865344a15948332b60c3d6d87862457