### PR TITLE
Add PR title stamping

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -26,7 +26,12 @@ jobs:
       - name: Prebuild
         run: CI=1 npx expo prebuild
 
-      - name: Stamp app name with timestamp
+      - name: Get PR title
+        run: echo "PR_TITLE=$(gh pr view --json title -q .title)" >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stamp app name with PR title and timestamp
         run: node scripts/stamp-app-name.js
 
       - name: Publish to Expo

--- a/scripts/stamp-app-name.js
+++ b/scripts/stamp-app-name.js
@@ -1,15 +1,25 @@
 // scripts/stamp-app-name.js
+// Update the Expo app name with the PR title and a timestamp.
 const fs = require('fs');
 const path = require('path');
 
 const appJsonPath = path.join(__dirname, '..', 'app.json');
-const appJson = require(appJsonPath);
+const appJson = JSON.parse(fs.readFileSync(appJsonPath));
 
+// Get the PR title from environment or fallback
+const rawTitle = process.env.PR_TITLE || 'NoTitle';
+
+// Remove special characters except spaces and hyphens, then truncate
+const sanitized = rawTitle.replace(/[^a-zA-Z0-9\s-]/g, '').trim();
+const shortTitle = sanitized.substring(0, 20) || 'NoTitle';
+
+// Timestamp in HH:mm DD-MM-YY
 const now = new Date();
 const pad = (n) => n.toString().padStart(2, '0');
-const timestamp = `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
+const timestamp = `${pad(now.getHours())}:${pad(now.getMinutes())} ${pad(now.getDate())}-${pad(now.getMonth() + 1)}-${now.getFullYear().toString().slice(-2)}`;
 
-appJson.expo.name = `HydroComp ${timestamp}`;
+const newName = `hydcom-${shortTitle}-${timestamp}`;
+appJson.expo.name = newName;
 
 fs.writeFileSync(appJsonPath, JSON.stringify(appJson, null, 2));
-console.log(`✔ App name updated to: "${appJson.expo.name}"`);
+console.log(`✔ App name updated to: "${newName}"`);


### PR DESCRIPTION
## Summary
- update `stamp-app-name.js` to include PR title and timestamp
- update `eas-update` workflow to fetch PR title and stamp app name before publishing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865d9da9ba083328707bbd449d8f160