### PR TITLE
Add camera troubleshooting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # HydCom
 Hydrogropher's Companion App
+
+## Troubleshooting Camera Issues
+
+If the camera view shows a blank screen even after granting permissions:
+
+1. Reinstall the camera module to ensure it is properly linked:
+
+   ```bash
+   expo install expo-camera
+   ```
+
+2. Restart the Expo development server:
+
+   ```bash
+   npx expo start -c
+   ```
+
+3. Force quit and reopen the Expo Go app on your device.

--- a/expo_setup_guide.md
+++ b/expo_setup_guide.md
@@ -550,6 +550,12 @@ const styles = StyleSheet.create({
 
 **Barcode scanner black screen?**
 - Grant camera permission in iPhone Settings > Expo Go > Camera
+- If the screen stays blank, reinstall the camera module and restart Expo:
+
+  ```bash
+  expo install expo-camera
+  npx expo start -c
+  ```
 
 **App crashes?**
 - Check Command Prompt for error messages


### PR DESCRIPTION
## Summary
- document fix for blank camera screen in README
- mention reinstalling expo-camera in troubleshooting guide

## Testing
- `npm test` *(fails: Missing script)*
- `npx expo install expo-camera` *(fails: prompts to install expo CLI)*

------
https://chatgpt.com/codex/tasks/task_e_6865fd9287a883328bb3dc9a585b28d8