### PR TITLE
Fix expo start error by adding tslib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # HydCom
 Hydrogropher's Companion App
 
+## Getting Started
+
+After cloning or pulling new updates, install dependencies to ensure all required modules (like `tslib`) are present:
+
+```bash
+npm install
+```
+
+This step is required whenever `package.json` changes.
+
 ## Troubleshooting Camera Issues
 
 If the camera view shows a blank screen even after granting permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-native-svg": "15.11.2",
         "suncalc": "^1.9.0",
         "three": "^0.145.0",
+        "tslib": "^2.8.1",
         "victory": "^37.3.6",
         "victory-native": "^41.17.4"
       },
@@ -9423,6 +9424,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-three": "^7.0.0",
     "expo-gl": "~13.0.0",
     "suncalc": "^1.9.0",
+    "tslib": "^2.8.1",
     "victory": "^37.3.6",
     "victory-native": "^41.17.4"
   },


### PR DESCRIPTION
## Summary
- add `tslib` as a dependency so expo-updates CLI can load
- document running `npm install` after pulling changes

## Testing
- `npm install`
- `npx expo start --dev-client` *(starts Metro)*

------
https://chatgpt.com/codex/tasks/task_e_6867c6c19ffc8332a739e62fcb9387d6