### PR TITLE
Fix reanimated runtime error

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ After cloning or pulling new updates, install dependencies to ensure all require
 ```bash
 npm install
 ```
+If you encounter an error about `react-native-reanimated` when running the app, install it via:
+```bash
+npx expo install react-native-reanimated
+```
 
 This step is required whenever `package.json` changes.
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "19.0.0",
         "react-native": "0.79.5",
         "react-native-maps": "1.20.1",
+        "react-native-reanimated": "~3.18.0",
         "react-native-svg": "15.11.2",
         "suncalc": "^1.9.0",
         "three": "^0.145.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-maps": "1.20.1",
+    "react-native-reanimated": "~3.18.0",
     "react-native-svg": "15.11.2",
     "three": "^0.145.0",
     "expo-three": "^7.0.0",


### PR DESCRIPTION
## Summary
- add `react-native-reanimated` dependency
- add babel plugin configuration
- document how to install reanimated when needed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867d74fa5348332afe537701b4b10d8