### PR TITLE
Fix EAS workflow dependencies

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Install expo-camera
         run: npx expo install expo-camera
 
+      - name: Install additional Expo packages
+        run: |
+          npx expo install expo-location expo-file-system expo-media-library \
+            expo-barcode-scanner expo-sqlite expo-sensors expo-status-bar \
+            expo-gl expo-three
+
       - name: Prebuild
         run: CI=1 npx expo prebuild
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ If you encounter an error about `react-native-reanimated` when running the app, 
 npx expo install react-native-reanimated
 ```
 
+Ensure `index.js` imports `react-native-reanimated` before other modules:
+
+```javascript
+import 'react-native-reanimated';
+```
+
 This step is required whenever `package.json` changes.
 
 ## Troubleshooting Camera Issues

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import 'react-native-reanimated';
 import { registerRootComponent } from 'expo';
 
 import App from './App';


### PR DESCRIPTION
## Summary
- add required `react-native-reanimated` import
- ensure all Expo dependencies are installed in EAS workflow
- document reanimated import

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68684242c2188332b9dabb457e360af2