### PR TITLE
Add global error boundary

### DIFF
--- a/App.js
+++ b/App.js
@@ -83,7 +83,7 @@ export default function App() {
   };
 
   return (
-    <ErrorBoundary>
+    <ErrorBoundary logToFile>
       <ScrollView style={styles.container}>
       <StatusBar style="auto" />
       

--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text, StyleSheet, Button } from 'react-native';
+import * as FileSystem from 'expo-file-system';
 import * as Sentry from 'sentry-expo';
 
 class ErrorBoundary extends React.Component {
@@ -12,18 +13,40 @@ class ErrorBoundary extends React.Component {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error, errorInfo) {
+  async componentDidCatch(error, errorInfo) {
     console.error('Unhandled error:', error, errorInfo);
     Sentry.Native.captureException(error);
+    if (this.props.logToFile) {
+      try {
+        const logFile = FileSystem.documentDirectory + 'error-log.txt';
+        const existing = await FileSystem.readAsStringAsync(logFile).catch(() => '');
+        const log = `${new Date().toISOString()}\n${error.toString()}\n${JSON.stringify(errorInfo)}\n\n`;
+        await FileSystem.writeAsStringAsync(logFile, existing + log, {
+          encoding: FileSystem.EncodingType.UTF8
+        });
+      } catch (fileError) {
+        console.error('Failed to write error log:', fileError);
+      }
+    }
   }
+
+  reset = () => this.setState({ hasError: false, error: null });
 
   render() {
     if (this.state.hasError) {
+      if (__DEV__) {
+        return (
+          <View style={[styles.container, styles.devOverlay]}>
+            <Text style={styles.details}>{this.state.error?.toString()}</Text>
+            <Button title="Dismiss" onPress={this.reset} />
+          </View>
+        );
+      }
+
       return (
         <View style={styles.container}>
-          <Text style={styles.title}>🚨 App Error</Text>
-          <Text style={styles.message}>Something went wrong.</Text>
-          <Text style={styles.details}>{this.state.error?.toString()}</Text>
+          <Text style={styles.title}>App crashed</Text>
+          <Button title="Retry" onPress={this.reset} />
         </View>
       );
     }
@@ -36,7 +59,10 @@ const styles = StyleSheet.create({
   container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: 20 },
   title: { fontSize: 24, fontWeight: 'bold', marginBottom: 10 },
   message: { fontSize: 16, color: 'gray', marginBottom: 10 },
-  details: { fontSize: 12, color: 'darkred' }
+  details: { fontSize: 12, color: 'darkred', marginBottom: 10 },
+  devOverlay: {
+    backgroundColor: 'rgba(255,0,0,0.8)'
+  }
 });
 
 export default ErrorBoundary;


### PR DESCRIPTION
## Summary
- enhance error boundary with optional file logging
- display red overlay in dev and fallback screen in production
- pass `logToFile` prop from `App`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868d6d22f18833295d6922262af00b6