### PR TITLE
Fix EAS workflow dependency versions

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm ci || npm install
 
       - name: Install expo-cli and eas-cli
-        run: npm install -g expo-cli eas-cli
+        run: npm install -g expo-cli@6.3.10 eas-cli@16.13.4
 
       - name: Install expo-updates (if needed)
         run: npx expo install expo-updates


### PR DESCRIPTION
## Summary
- pin global expo-cli and eas-cli versions in server workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868d92adfe883329a0bdef9c6c4e8a1