### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,32 +8,32 @@
       "name": "hydcom",
       "version": "1.0.0",
       "dependencies": {
-        "expo": "~53.0.11",
+        "expo": "~53.0.17",
         "expo-barcode-scanner": "^13.0.1",
-        "expo-camera": "~16.1.8",
-        "expo-file-system": "~18.1.10",
+        "expo-camera": "~16.1.10",
+        "expo-file-system": "~18.1.11",
         "expo-gl": "~15.1.7",
-        "expo-location": "~18.1.5",
+        "expo-location": "~18.1.6",
         "expo-media-library": "~17.1.7",
         "expo-sensors": "~14.1.4",
-        "expo-sqlite": "~15.2.12",
+        "expo-sqlite": "~15.2.13",
         "expo-status-bar": "~2.2.3",
-        "expo-three": "^7.0.0",
+        "expo-three": "^8.0.0",
         "expo-updates": "~0.28.16",
-        "react": "19.0.0",
-        "react-native": "0.79.5",
-        "react-native-maps": "1.20.1",
+        "react": "19.1.0",
+        "react-native": "0.80.1",
+        "react-native-maps": "1.24.3",
         "react-native-reanimated": "~3.18.0",
-        "react-native-svg": "15.11.2",
-        "sentry-expo": "~7.0.0",
+        "react-native-svg": "15.12.0",
+        "sentry-expo": "~7.2.0",
         "suncalc": "^1.9.0",
-        "three": "^0.145.0",
+        "three": "^0.166.1",
         "tslib": "^2.8.1",
         "victory": "^37.3.6",
         "victory-native": "^41.17.4"
       },
       "devDependencies": {
-        "@babel/core": "^7.20.0"
+        "@babel/core": "^7.28.0"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -1538,29 +1538,29 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.24.16",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.16.tgz",
-      "integrity": "sha512-nzfWj5iN8kBeH5iVsfw0XjrUxIK4Td+WayxgnBbBZ27iczGnRPaWT+SSea3EoaaiWqcwkV0xgLQkd0qpTsaEhg==",
+      "version": "0.24.18",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.18.tgz",
+      "integrity": "sha512-4cUVWa7bHS0oLn9hBCH5QKI47o+qm0JTUl8xINC0In0JIG9mlLugDSNY+t81powr28Htq9n5gOGkKPTGc1vKiw==",
       "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.8",
         "@babel/runtime": "^7.20.0",
         "@expo/code-signing-certificates": "^0.0.5",
-        "@expo/config": "~11.0.11",
-        "@expo/config-plugins": "~10.0.3",
+        "@expo/config": "~11.0.12",
+        "@expo/config-plugins": "~10.1.1",
         "@expo/devcert": "^1.1.2",
-        "@expo/env": "~1.0.6",
-        "@expo/image-utils": "^0.7.5",
-        "@expo/json-file": "^9.1.4",
-        "@expo/metro-config": "~0.20.15",
-        "@expo/osascript": "^2.2.4",
-        "@expo/package-manager": "^1.8.5",
-        "@expo/plist": "^0.3.4",
-        "@expo/prebuild-config": "^9.0.8",
+        "@expo/env": "~1.0.7",
+        "@expo/image-utils": "^0.7.6",
+        "@expo/json-file": "^9.1.5",
+        "@expo/metro-config": "~0.20.17",
+        "@expo/osascript": "^2.2.5",
+        "@expo/package-manager": "^1.8.6",
+        "@expo/plist": "^0.3.5",
+        "@expo/prebuild-config": "^9.0.10",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
         "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.79.4",
+        "@react-native/dev-middleware": "0.79.5",
         "@urql/core": "^5.0.6",
         "@urql/exchange-retry": "^1.3.0",
         "accepts": "^1.3.8",
@@ -1653,14 +1653,14 @@
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.0.3.tgz",
-      "integrity": "sha512-fjCckkde67pSDf48x7wRuPsgQVIqlDwN7NlOk9/DFgQ1hCH0L5pGqoSmikA1vtAyiA83MOTpkGl3F3wyATyUog==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.1.1.tgz",
+      "integrity": "sha512-2L/ryY/R/AzwHfLpzBBsj0qdwN+E2RkF24uwo33L7M5DOswbLVaA007IdLlun+G6ctZYnwgm3TDLxjbvqZ9Avw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^53.0.4",
-        "@expo/json-file": "~9.1.4",
-        "@expo/plist": "^0.3.4",
+        "@expo/config-types": "^53.0.5",
+        "@expo/json-file": "~9.1.5",
+        "@expo/plist": "^0.3.5",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
@@ -1701,28 +1701,6 @@
         "@babel/highlight": "^7.10.4"
       }
     },
-    "node_modules/@expo/config/node_modules/@expo/config-plugins": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.1.1.tgz",
-      "integrity": "sha512-2L/ryY/R/AzwHfLpzBBsj0qdwN+E2RkF24uwo33L7M5DOswbLVaA007IdLlun+G6ctZYnwgm3TDLxjbvqZ9Avw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^53.0.5",
-        "@expo/json-file": "~9.1.5",
-        "@expo/plist": "^0.3.5",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slash": "^3.0.0",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
     "node_modules/@expo/config/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -1756,9 +1734,9 @@
       }
     },
     "node_modules/@expo/env": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-1.0.6.tgz",
-      "integrity": "sha512-aokrM+EYgyaJNmyo8QhphP3egVi0E7/4PiAx+riW1k39wu26POCg5NBdOSBHoYGmq1NXbhpFepIFDWVaCw1UeA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-1.0.7.tgz",
+      "integrity": "sha512-qSTEnwvuYJ3umapO9XJtrb1fAqiPlmUUg78N0IZXXGwQRt+bkp0OBls+Y5Mxw/Owj8waAM0Z3huKKskRADR5ow==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -1769,9 +1747,9 @@
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.13.3.tgz",
-      "integrity": "sha512-Ziore8lpUzTvZaZigcol0op3muvEiBpwNn8M500qij/RvVFLEOH5sNadEBKwEmzdpUC5ij3eJzkr9b7Gr7///g==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.13.4.tgz",
+      "integrity": "sha512-MYfPYBTMfrrNr07DALuLhG6EaLVNVrY/PXjEzsjWdWE4ZFn0yqI0IdHNkJG7t1gePT8iztHc7qnsx+oo/rDo6w==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -1804,9 +1782,9 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.7.5.tgz",
-      "integrity": "sha512-92sk+dplZHlZuv4jAWmGBOqWf70hcb0zoObmjQRgxvZbKWXlQ6ifANaOUhoeJKgNWSB9BrLoW6v/mUyrDUdK+A==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.7.6.tgz",
+      "integrity": "sha512-GKnMqC79+mo/1AFrmAcUcGfbsXXTRqOMNS1umebuevl3aaw+ztsYEFEiuNhHZW7PQ3Xs3URNT513ZxKhznDscw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -1852,18 +1830,18 @@
       }
     },
     "node_modules/@expo/metro-config": {
-      "version": "0.20.15",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.20.15.tgz",
-      "integrity": "sha512-m8i58IQ7I8iOdVRfOhFmhPMHuhgeTVfQp1+mxW7URqPZaeVbuDVktPqOiNoHraKBoGPLKMUSsD+qdUuJVL3wMg==",
+      "version": "0.20.17",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.20.17.tgz",
+      "integrity": "sha512-lpntF2UZn5bTwrPK6guUv00Xv3X9mkN3YYla+IhEHiYXWyG7WKOtDU0U4KR8h3ubkZ6SPH3snDyRyAzMsWtZFA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.0",
         "@babel/generator": "^7.20.5",
         "@babel/parser": "^7.20.0",
         "@babel/types": "^7.20.0",
-        "@expo/config": "~11.0.10",
-        "@expo/env": "~1.0.5",
-        "@expo/json-file": "~9.1.4",
+        "@expo/config": "~11.0.12",
+        "@expo/env": "~1.0.7",
+        "@expo/json-file": "~9.1.5",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.0",
         "debug": "^4.3.2",
@@ -1879,9 +1857,9 @@
       }
     },
     "node_modules/@expo/osascript": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.2.4.tgz",
-      "integrity": "sha512-Q+Oyj+1pdRiHHpev9YjqfMZzByFH8UhKvSszxa0acTveijjDhQgWrq4e9T/cchBHi0GWZpGczWyiyJkk1wM1dg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.2.5.tgz",
+      "integrity": "sha512-Bpp/n5rZ0UmpBOnl7Li3LtM7la0AR3H9NNesqL+ytW5UiqV/TbonYW3rDZY38u4u/lG7TnYflVIVQPD+iqZJ5w==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.2",
@@ -1892,12 +1870,12 @@
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.8.5.tgz",
-      "integrity": "sha512-C9dl6GLUtzeY80g5wxOnZ/tEdAlSlCh8h6vTJkuTM9dPtdpQwg40w0/Gx4ONKeegExYLlGDw7dilL+xrxz/d+w==",
+      "version": "1.8.6",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.8.6.tgz",
+      "integrity": "sha512-gcdICLuL+nHKZagPIDC5tX8UoDDB8vNA5/+SaQEqz8D+T2C4KrEJc2Vi1gPAlDnKif834QS6YluHWyxjk0yZlQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^9.1.4",
+        "@expo/json-file": "^9.1.5",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
@@ -1917,17 +1895,17 @@
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-9.0.8.tgz",
-      "integrity": "sha512-vzORt1zrgjIYOKAmHk0SUka0rlYo0AIZpOF6019ms2XaQnxyvcQACz1BxTk2++fTAzSAxerufNQOm2owPcAz+g==",
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-9.0.10.tgz",
+      "integrity": "sha512-lpzuel+Qb3QvGV0mnFOfeiyTq8pTGmnoGIX7p/enEgwjaCOUMSfOkbZkn6QJNAHOgNE1z5PAqzO1EBQPj2jrfA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~11.0.10",
-        "@expo/config-plugins": "~10.0.3",
-        "@expo/config-types": "^53.0.4",
-        "@expo/image-utils": "^0.7.4",
-        "@expo/json-file": "^9.1.4",
-        "@react-native/normalize-colors": "0.79.4",
+        "@expo/config": "~11.0.12",
+        "@expo/config-plugins": "~10.1.1",
+        "@expo/config-types": "^53.0.5",
+        "@expo/image-utils": "^0.7.6",
+        "@expo/json-file": "^9.1.5",
+        "@react-native/normalize-colors": "0.79.5",
         "debug": "^4.3.1",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0",
@@ -2332,31 +2310,31 @@
       }
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
-      "integrity": "sha512-N4Kt1cKxO5zgM/BLiyzuuDNquZPiIgfktEQ6TqJ/4nKA8zr4e8KJgU6Tb2eleihDO4E24HmkvGc73naybKRz/w==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.80.1.tgz",
+      "integrity": "sha512-T3C8OthBHfpFIjaGFa0q6rc58T2AsJ+jKAa+qPquMKBtYGJMc75WgNbk/ZbPBxeity6FxZsmg3bzoUaWQo4Mow==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.4.tgz",
-      "integrity": "sha512-quhytIlDedR3ircRwifa22CaWVUVnkxccrrgztroCZaemSJM+HLurKJrjKWm0J5jV9ed+d+9Qyb1YB0syTHDjg==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.5.tgz",
+      "integrity": "sha512-Rt/imdfqXihD/sn0xnV4flxxb1aLLjPtMF1QleQjEhJsTUPpH4TFlfOpoCvsrXoDl4OIcB1k4FVM24Ez92zf5w==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.79.4"
+        "@react-native/codegen": "0.79.5"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.4.tgz",
-      "integrity": "sha512-El9JvYKiNfnkQ3qR7zJvvRdP3DX2i4BGYlIricWQishI3gWAfm88FQYFC2CcGoMQWJQEPN4jnDMpoISAJDEN4g==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.5.tgz",
+      "integrity": "sha512-GDUYIWslMLbdJHEgKNfrOzXk8EDKxKzbwmBXUugoiSlr6TyepVZsj3GZDLEFarOcTwH1EXXHJsixihk8DCRQDA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -2400,7 +2378,7 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.79.4",
+        "@react-native/babel-plugin-codegen": "0.79.5",
         "babel-plugin-syntax-hermes-parser": "0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
@@ -2413,9 +2391,9 @@
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.4.tgz",
-      "integrity": "sha512-K0moZDTJtqZqSs+u9tnDPSxNsdxi5irq8Nu4mzzOYlJTVNGy5H9BiIDg/NeKGfjAdo43yTDoaPSbUCvVV8cgIw==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.5.tgz",
+      "integrity": "sha512-FO5U1R525A1IFpJjy+KVznEinAgcs3u7IbnbRJUG9IH/MBXi2lEU2LtN+JarJ81MCfW4V2p0pg6t/3RGHFRrlQ==",
       "license": "MIT",
       "dependencies": {
         "glob": "^7.1.1",
@@ -2475,18 +2453,18 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.5.tgz",
-      "integrity": "sha512-ApLO1ARS8JnQglqS3JAHk0jrvB+zNW3dvNJyXPZPoygBpZVbf8sjvqeBiaEYpn8ETbFWddebC4HoQelDndnrrA==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.80.1.tgz",
+      "integrity": "sha512-M1lzLvZUz6zb6rn4Oyc3HUY72wye8mtdm1bJSYIBoK96ejMvQGoM+Lih/6k3c1xL7LSruNHfsEXXePLjCbhE8Q==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.5",
+        "@react-native/dev-middleware": "0.80.1",
         "chalk": "^4.0.0",
-        "debug": "^2.2.0",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.82.0",
-        "metro-config": "^0.82.0",
-        "metro-core": "^0.82.0",
+        "metro": "^0.82.2",
+        "metro-config": "^0.82.2",
+        "metro-core": "^0.82.2",
         "semver": "^7.1.3"
       },
       "engines": {
@@ -2502,26 +2480,26 @@
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.5.tgz",
-      "integrity": "sha512-WQ49TRpCwhgUYo5/n+6GGykXmnumpOkl4Lr2l2o2buWU9qPOwoiBqJAtmWEXsAug4ciw3eLiVfthn5ufs0VB0A==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.80.1.tgz",
+      "integrity": "sha512-5dQJdX1ZS4dINNw51KNsDIL+A06sZQd2hqN2Pldq5SavxAwEJh5NxAx7K+lutKhwp1By5gxd6/9ruVt+9NCvKA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.5.tgz",
-      "integrity": "sha512-U7r9M/SEktOCP/0uS6jXMHmYjj4ESfYCkNAenBjFjjsRWekiHE+U/vRMeO+fG9gq4UCcBAUISClkQCowlftYBw==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.80.1.tgz",
+      "integrity": "sha512-EBnZ3s6+hGAlUggDvo9uI37Xh0vG55H2rr3A6l6ww7+sgNuUz+wEJ63mGINiU6DwzQSgr6av7rjrVERxKH6vxg==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.5",
+        "@react-native/debugger-frontend": "0.80.1",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
-        "debug": "^2.2.0",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
@@ -2531,21 +2509,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
       "version": "7.7.2",
@@ -2569,22 +2532,22 @@
       }
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.4.tgz",
-      "integrity": "sha512-Gg4LhxHIK86Bi2RiT1rbFAB6fuwANRsaZJ1sFZ1OZEMQEx6stEnzaIrmfgzcv4z0bTQdQ8lzCrpsz0qtdaD4eA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.5.tgz",
+      "integrity": "sha512-WQ49TRpCwhgUYo5/n+6GGykXmnumpOkl4Lr2l2o2buWU9qPOwoiBqJAtmWEXsAug4ciw3eLiVfthn5ufs0VB0A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.4.tgz",
-      "integrity": "sha512-OWRDNkgrFEo+OSC5QKfiiBmGXKoU8gmIABK8rj2PkgwisFQ/22p7MzE5b6oB2lxWaeJT7jBX5KVniNqO46VhHA==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.5.tgz",
+      "integrity": "sha512-U7r9M/SEktOCP/0uS6jXMHmYjj4ESfYCkNAenBjFjjsRWekiHE+U/vRMeO+fG9gq4UCcBAUISClkQCowlftYBw==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.4",
+        "@react-native/debugger-frontend": "0.79.5",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
@@ -2624,77 +2587,86 @@
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.5.tgz",
-      "integrity": "sha512-K3QhfFNKiWKF3HsCZCEoWwJPSMcPJQaeqOmzFP4RL8L3nkpgUwn74PfSCcKHxooVpS6bMvJFQOz7ggUZtNVT+A==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.80.1.tgz",
+      "integrity": "sha512-6B7bWUk27ne/g/wCgFF4MZFi5iy6hWOcBffqETJoab6WURMyZ6nU+EAMn+Vjhl5ishhUvTVSrJ/1uqrxxYQO2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.5.tgz",
-      "integrity": "sha512-a2wsFlIhvd9ZqCD5KPRsbCQmbZi6KxhRN++jrqG0FUTEV5vY7MvjjUqDILwJd2ZBZsf7uiDuClCcKqA+EEdbvw==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.80.1.tgz",
+      "integrity": "sha512-cWd5Cd2kBMRM37dor8N9Ck4X0NzjYM3m8K6HtjodcOdOvzpXfrfhhM56jdseTl5Z4iB+pohzPJpSmFJctmuIpA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.79.4",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.4.tgz",
-      "integrity": "sha512-247/8pHghbYY2wKjJpUsY6ZNbWcdUa5j5517LZMn6pXrbSSgWuj3JA4OYibNnocCHBaVrt+3R8XC3VEJqLlHFg==",
+      "version": "0.79.5",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
+      "integrity": "sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==",
       "license": "MIT"
     },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.1.tgz",
-      "integrity": "sha512-6N99rE+Ek0LgbqSzI/XpsKSLUyJjQ9nychViy+MP60p1x+hllukfTsDbNtUNrPlW0Bx+vqUrWKkAqmTFad94TQ==",
+    "node_modules/@react-native/virtualized-lists": {
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.80.1.tgz",
+      "integrity": "sha512-nqQAeHheSNZBV+syhLVMgKBZv+FhCANfxAWVvfEXZa4rm5jGHsj3yA9vqrh2lcJL3pjd7PW5nMX7TcuJThEAgQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.52.1",
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "tslib": "^1.9.3"
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.0.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.81.1.tgz",
+      "integrity": "sha512-E5xm27xrLXL10knH2EWDQsQYh5nb4SxxZzJ3sJwDGG9XGKzBdlp20UUhKqx00wixooVX9uCj3e4Jg8SvNB1hKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.81.1",
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@sentry-internal/tracing/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/@sentry/browser": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.52.1.tgz",
-      "integrity": "sha512-HrCOfieX68t+Wj42VIkraLYwx8kN5311SdBkHccevWs2Y2dZU7R9iLbI87+nb5kpOPQ7jVWW7d6QI/yZmliYgQ==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.81.1.tgz",
+      "integrity": "sha512-DNtS7bZEnFPKVoGazKs5wHoWC0FwsOFOOMNeDvEfouUqKKbjO7+RDHbr7H6Bo83zX4qmZWRBf8V+3n3YPIiJFw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/tracing": "7.52.1",
-        "@sentry/core": "7.52.1",
-        "@sentry/replay": "7.52.1",
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "tslib": "^1.9.3"
+        "@sentry-internal/tracing": "7.81.1",
+        "@sentry/core": "7.81.1",
+        "@sentry/replay": "7.81.1",
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
     "node_modules/@sentry/cli": {
-      "version": "2.17.5",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.17.5.tgz",
-      "integrity": "sha512-0tXjLDpaKB46851EMJ6NbP0o9/gdEaDSLAyjEtXxlVO6+RyhUj6x6jDwn0vis8n/7q0AvbIjAcJrot+TbZP+WQ==",
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.25.2.tgz",
+      "integrity": "sha512-lgt1QPaCfs/QZNXwyw3gvuBR2/CLwFSdU/oT7Bpxwizz8XVXhlKS98zJF1UVCy7SecsDSoOI0Z+B+X658cpquQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -2709,6 +2681,130 @@
       },
       "engines": {
         "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.25.2",
+        "@sentry/cli-linux-arm": "2.25.2",
+        "@sentry/cli-linux-arm64": "2.25.2",
+        "@sentry/cli-linux-i686": "2.25.2",
+        "@sentry/cli-linux-x64": "2.25.2",
+        "@sentry/cli-win32-i686": "2.25.2",
+        "@sentry/cli-win32-x64": "2.25.2"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.25.2.tgz",
+      "integrity": "sha512-o1d5NnVUrc1dxDm56k7Co8tSTcOuxbApdxweVXXsiq20HblZCyIi7WxxRkAg4RfKx594sKGiw9uCVvECi+9UpA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.25.2.tgz",
+      "integrity": "sha512-n398jd87Ymejt5k/6RjCEjXAvntOWuqhBDANxzhgr5/9FzbODJ844g1mOpcxiIlduzKSzWlPbTEKQulMp2Mt4w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.25.2.tgz",
+      "integrity": "sha512-lm5jaigV6xu9Gwo0wNk+bX6yVkl5k3gNXcSXcKCISFo+Teb7Zhf9IyXANPm4VY2DdiZAjPJt8gS1bu+Mn7irtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.25.2.tgz",
+      "integrity": "sha512-/YYx2gfqO5mkxyBgFcnDbZzkZ2+2xNarwrqWcqq3Qw0XlO9DWAQB2G+twV1RW/UfSU6fFIWErn94efh2EWmyzQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.25.2.tgz",
+      "integrity": "sha512-rRafqy84R5mYA4JEfNsUeN10af5euJnK7fgqYM0mJIaplHC2YEXT9aUYWoryWPZiYqmdNUhsA6lX7iynSW9pZw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.25.2.tgz",
+      "integrity": "sha512-plT/gi41F+67g9AwrEm4avRXnjCtHCcnRnJ6zPu/iINGap8mvYQJSU/qM0oGwV6hRGg3JJN66XIvJPIuIs8P8w==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.25.2",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.25.2.tgz",
+      "integrity": "sha512-Mb6mAyPi9gIfpzF5MTk0JXgFP9nxka3Fb7JYn6AY4RW++sOjapkTrcXL2Gp3ZfQkWj5rFTgln4+eNmZPsD2gzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@sentry/cli/node_modules/agent-base": {
@@ -2737,144 +2833,82 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.1.tgz",
-      "integrity": "sha512-36clugQu5z/9jrit1gzI7KfKbAUimjRab39JeR0mJ6pMuKLTTK7PhbpUAD4AQBs9qVeXN2c7h9SVZiSA0UDvkg==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.81.1.tgz",
+      "integrity": "sha512-tU37yAmckOGCw/moWKSwekSCWWJP15O6luIq+u7wal22hE88F3Vc5Avo8SeF3upnPR+4ejaOFH+BJTr6bgrs6Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/@sentry/hub": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.52.0.tgz",
-      "integrity": "sha512-w3d8Pmp3Fx2zbbjz6hAeIbsFEkLyrUs9YTGG2y8oCoTlAtGK+AjdG+Z0H/clAZONflD/je2EmFHCI0EuXE9tEw==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.81.1.tgz",
+      "integrity": "sha512-25cvsI3HKiRLJBZGFC8ntuy7/yB8M1w8YLTjr3tIqydYmjFUX7f18w0iuWEtd204d8OQSPBJDapbGMdfkE5x6w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.52.0",
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.81.1",
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@sentry/hub/node_modules/@sentry/core": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.0.tgz",
-      "integrity": "sha512-BWdG6vCMeUeMhF4ILpxXTmw70JJvT1MGJcnv09oSupWHTmqy6I19YP6YcEyFuBL4jXPN51eCl7luIdLGJrPbOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/@sentry/types": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
-      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/@sentry/utils": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
-      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/@sentry/integrations": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.52.1.tgz",
-      "integrity": "sha512-4uejF01723wzEHjcP5AcNcV+Z/6U27b1LyaDu0jY3XDry98MMjhS/ASzecLpaEFxi3dh/jMTUrNp1u7WMj59Lg==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.81.1.tgz",
+      "integrity": "sha512-DN5ONn0/LX5HHVPf1EBGHFssIZaZmLgkqUIeMqCNYBpB4DiOrJANnGwTcWKDPphqhdPxjnPv9AGRLaU0PdvvZQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "localforage": "^1.8.1",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.81.1",
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/integrations/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
-    },
     "node_modules/@sentry/replay": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.52.1.tgz",
-      "integrity": "sha512-A+RaUmpU9/yBHnU3ATemc6wAvobGno0yf5R6fZYkAFoo2FCR2YG6AXxkTazymIf8v2DnLGaSDORYDPdhQClU9A==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.81.1.tgz",
+      "integrity": "sha512-4ueT0C4bYjngN/9p0fEYH10dTMLovHyk9HxJ6zSTgePvGVexhg+cSEHXisoBDwHeRZVnbIvsVM0NA7rmEDXJJw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.52.1",
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1"
+        "@sentry-internal/tracing": "7.81.1",
+        "@sentry/core": "7.81.1",
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.1.tgz",
-      "integrity": "sha512-OMbGBPrJsw0iEXwZ2bJUYxewI1IEAU2e1aQGc0O6QW5+6hhCh+8HO8Xl4EymqwejjztuwStkl6G1qhK+Q0/Row==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.81.1.tgz",
+      "integrity": "sha512-dvJvGyctiaPMIQqa46k56Re5IODWMDxiHJ1UjBs/WYDLrmWFPGrEbyJ8w8CYLhYA+7qqrCyIZmHbWSTRIxstHw==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.1.tgz",
-      "integrity": "sha512-MPt1Xu/jluulknW8CmZ2naJ53jEdtdwCBSo6fXJvOTI0SDqwIPbXDVrsnqLAhVJuIN7xbkj96nuY/VBR6S5sWg==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.81.1.tgz",
+      "integrity": "sha512-gq+MDXIirHKxNZ+c9/lVvCXd6y2zaZANujwlFggRH2u9SRiPaIXVilLpvMm4uJqmqBMEcY81ArujExtHvkbCqg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/types": "7.52.1",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.81.1"
       },
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/@shopify/react-native-skia": {
       "version": "2.1.0",
@@ -3483,9 +3517,9 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.1.tgz",
-      "integrity": "sha512-Ol3w0uLJNQ5tDfCf4L+IDTDMgJkVMQHhvYqMxs18Ib0DcaBQIfE8mneSSk7FcuI6FS0phw/rZhoEquQh1/Q3wA==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.3.tgz",
+      "integrity": "sha512-wQJn92lqj8GKR7Ojg/aW4+GkqI6ZdDNTDyOqhhl7A9bAqk6t0ukUOWLDXQb4p0qKJjMDV1F6gNWasI2KUbuVTQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
@@ -3502,7 +3536,7 @@
         "@babel/plugin-transform-runtime": "^7.24.7",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.79.4",
+        "@react-native/babel-preset": "0.79.5",
         "babel-plugin-react-native-web": "~0.19.13",
         "babel-plugin-syntax-hermes-parser": "^0.25.1",
         "babel-plugin-transform-flow-enums": "^0.0.2",
@@ -4761,26 +4795,26 @@
       "license": "MIT"
     },
     "node_modules/expo": {
-      "version": "53.0.15",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.15.tgz",
-      "integrity": "sha512-tOMnpM1iHHUKcG6QzpE8Pm+d56XIyaxiOkXyDHiHrDziBMAI+ngBlZZ3xU/vuyMFiJWBCx5KAqiKsliKTEQi6Q==",
+      "version": "53.0.17",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.17.tgz",
+      "integrity": "sha512-I1z4X/BoirQeWH8VMcfW1N3OsKCY0LslGjhzDsBWomv4rzviLkcm7KNJBeYWddY7wGo0bljT8S57NGsIJS/f9g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.24.16",
-        "@expo/config": "~11.0.11",
-        "@expo/config-plugins": "~10.0.3",
-        "@expo/fingerprint": "0.13.3",
-        "@expo/metro-config": "0.20.15",
+        "@expo/cli": "0.24.18",
+        "@expo/config": "~11.0.12",
+        "@expo/config-plugins": "~10.1.1",
+        "@expo/fingerprint": "0.13.4",
+        "@expo/metro-config": "0.20.17",
         "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~13.2.1",
-        "expo-asset": "~11.1.6",
-        "expo-constants": "~17.1.6",
+        "babel-preset-expo": "~13.2.3",
+        "expo-asset": "~11.1.7",
+        "expo-constants": "~17.1.7",
         "expo-file-system": "~18.1.11",
         "expo-font": "~13.3.2",
         "expo-keep-awake": "~14.1.4",
         "expo-modules-autolinking": "2.1.13",
-        "expo-modules-core": "2.4.1",
+        "expo-modules-core": "2.4.2",
         "react-native-edge-to-edge": "1.6.0",
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -4854,13 +4888,13 @@
       }
     },
     "node_modules/expo-asset": {
-      "version": "11.1.6",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.6.tgz",
-      "integrity": "sha512-52wIPe0kVzgschXJ/cPCJ4N6r5z5ejQ0b+NOUZ8iwkWFfqynBNqFdGp4hPDjmNel39ukAQ57UNybiedRF4LZiw==",
+      "version": "11.1.7",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.7.tgz",
+      "integrity": "sha512-b5P8GpjUh08fRCf6m5XPVAh7ra42cQrHBIMgH2UXP+xsj4Wufl6pLy6jRF5w6U7DranUMbsXm8TOyq4EHy7ADg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.7.5",
-        "expo-constants": "~17.1.6"
+        "@expo/image-utils": "^0.7.6",
+        "expo-constants": "~17.1.7"
       },
       "peerDependencies": {
         "expo": "*",
@@ -4914,13 +4948,13 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "17.1.6",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.6.tgz",
-      "integrity": "sha512-q5mLvJiLtPcaZ7t2diSOlQ2AyxIO8YMVEJsEfI/ExkGj15JrflNQ7CALEW6IF/uNae/76qI/XcjEuuAyjdaCNw==",
+      "version": "17.1.7",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.7.tgz",
+      "integrity": "sha512-byBjGsJ6T6FrLlhOBxw4EaiMXrZEn/MlUYIj/JAd+FS7ll5X/S4qVRbIimSJtdW47hXMq0zxPfJX6njtA56hHA==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~11.0.9",
-        "@expo/env": "~1.0.5"
+        "@expo/config": "~11.0.12",
+        "@expo/env": "~1.0.7"
       },
       "peerDependencies": {
         "expo": "*",
@@ -5065,9 +5099,9 @@
       }
     },
     "node_modules/expo-modules-core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.4.1.tgz",
-      "integrity": "sha512-yCtYqvIDMLHu6nxo/ve5EOekTBNgSVb6F0B+0fCKCD0Fqid23DqdOhFUscsEltnhdKGfMyD1JRETkvhaJaXmJQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.4.2.tgz",
+      "integrity": "sha512-RCb0wniYCJkxwpXrkiBA/WiNGxzYsEpL0sB50gTnS/zEfX3DImS2npc4lfZ3hPZo1UF9YC6OSI9Do+iacV0NUg==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
@@ -5121,20 +5155,21 @@
       "license": "MIT"
     },
     "node_modules/expo-three": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/expo-three/-/expo-three-7.0.1.tgz",
-      "integrity": "sha512-B8OyGwjQZ+NbGBMT3zqe2ngV7mI147yJL8eR56y9SQLrsEkv8+DiMpm3f88r7/LJoFXKGg8mmMrK09hMvRqGHg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/expo-three/-/expo-three-8.0.0.tgz",
+      "integrity": "sha512-aGSxS7UEA0DtkdY9UdAHWW4JsJh4Q2vtOQNb3oocIP5bBazb6qTm0PtsXUF0YYo5s9TCJfm4t2ED+0LUz7QwaQ==",
       "license": "MIT",
       "dependencies": {
         "@expo/browser-polyfill": "^1.0.1",
         "expo-asset-utils": "~3.0.0"
       },
       "peerDependencies": {
+        "expo": "*",
         "expo-asset": "*",
         "expo-file-system": "*",
-        "expo-modules-core": "*",
+        "expo-gl": "*",
         "react-native": "*",
-        "three": "^0.145.0"
+        "three": "^0.166.0"
       }
     },
     "node_modules/expo-three/node_modules/@expo/browser-polyfill": {
@@ -5239,45 +5274,11 @@
         "expo": "*"
       }
     },
-    "node_modules/expo-updates/node_modules/@expo/config-plugins": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.1.1.tgz",
-      "integrity": "sha512-2L/ryY/R/AzwHfLpzBBsj0qdwN+E2RkF24uwo33L7M5DOswbLVaA007IdLlun+G6ctZYnwgm3TDLxjbvqZ9Avw==",
-      "license": "MIT",
-      "dependencies": {
-        "@expo/config-types": "^53.0.5",
-        "@expo/json-file": "~9.1.5",
-        "@expo/plist": "^0.3.5",
-        "@expo/sdk-runtime-versions": "^1.0.0",
-        "chalk": "^4.1.2",
-        "debug": "^4.3.5",
-        "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.5.4",
-        "slash": "^3.0.0",
-        "slugify": "^1.6.6",
-        "xcode": "^3.0.1",
-        "xml2js": "0.6.0"
-      }
-    },
     "node_modules/expo-updates/node_modules/arg": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
       "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
       "license": "MIT"
-    },
-    "node_modules/expo-updates/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
@@ -7774,9 +7775,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7826,42 +7827,41 @@
       "license": "MIT"
     },
     "node_modules/react-native": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
-      "integrity": "sha512-jVihwsE4mWEHZ9HkO1J2eUZSwHyDByZOqthwnGrVZCh6kTQBCm4v8dicsyDa6p0fpWNE5KicTcpX/XXl0ASJFg==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.80.1.tgz",
+      "integrity": "sha512-cIiJiPItdC2+Z9n30FmE2ef1y4522kgmOjMIoDtlD16jrOMNTUdB2u+CylLTy3REkWkWTS6w8Ub7skUthkeo5w==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.5",
-        "@react-native/codegen": "0.79.5",
-        "@react-native/community-cli-plugin": "0.79.5",
-        "@react-native/gradle-plugin": "0.79.5",
-        "@react-native/js-polyfills": "0.79.5",
-        "@react-native/normalize-colors": "0.79.5",
-        "@react-native/virtualized-lists": "0.79.5",
+        "@react-native/assets-registry": "0.80.1",
+        "@react-native/codegen": "0.80.1",
+        "@react-native/community-cli-plugin": "0.80.1",
+        "@react-native/gradle-plugin": "0.80.1",
+        "@react-native/js-polyfills": "0.80.1",
+        "@react-native/normalize-colors": "0.80.1",
+        "@react-native/virtualized-lists": "0.80.1",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "0.25.1",
+        "babel-plugin-syntax-hermes-parser": "0.28.1",
         "base64-js": "^1.5.1",
         "chalk": "^4.0.0",
         "commander": "^12.0.0",
-        "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
         "glob": "^7.1.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.7.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.82.0",
-        "metro-source-map": "^0.82.0",
+        "metro-runtime": "^0.82.2",
+        "metro-source-map": "^0.82.2",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
         "react-devtools-core": "^6.1.1",
         "react-refresh": "^0.14.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.25.0",
+        "scheduler": "0.26.0",
         "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
@@ -7875,8 +7875,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "^19.0.0"
+        "@types/react": "^19.1.0",
+        "react": "^19.1.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -7921,9 +7921,9 @@
       }
     },
     "node_modules/react-native-maps": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.20.1.tgz",
-      "integrity": "sha512-NZI3B5Z6kxAb8gzb2Wxzu/+P2SlFIg1waHGIpQmazDSCRkNoHNY4g96g+xS0QPSaG/9xRBbDNnd2f2/OW6t6LQ==",
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.24.3.tgz",
+      "integrity": "sha512-cF5oTA8z24QqGIRFfDcsXLEs/gCd0RhaJ9KPv/2HiogKD5gpjh1naimZUJQ6IsEcUngSSk8iov6p2jd7dB+/bQ==",
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "^7946.0.13"
@@ -7932,8 +7932,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "react": ">= 17.0.1",
-        "react-native": ">= 0.64.3",
+        "react": ">= 18.3.1",
+        "react-native": ">= 0.76.0",
         "react-native-web": ">= 0.11"
       },
       "peerDependenciesMeta": {
@@ -7978,9 +7978,9 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "15.11.2",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.11.2.tgz",
-      "integrity": "sha512-+YfF72IbWQUKzCIydlijV1fLuBsQNGMT6Da2kFlo1sh+LE3BIm/2Q7AR1zAAR6L0BFLi1WaQPLfFUC9bNZpOmw==",
+      "version": "15.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.0.tgz",
+      "integrity": "sha512-iE25PxIJ6V0C6krReLquVw6R0QTsRTmEQc4K2Co3P6zsimU/jltcDBKYDy1h/5j9S/fqmMeXnpM+9LEWKJKI6A==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",
@@ -7993,13 +7993,13 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.5.tgz",
-      "integrity": "sha512-FO5U1R525A1IFpJjy+KVznEinAgcs3u7IbnbRJUG9IH/MBXi2lEU2LtN+JarJ81MCfW4V2p0pg6t/3RGHFRrlQ==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.80.1.tgz",
+      "integrity": "sha512-CFhOYkXmExOeZDZnd0UJCK9A4AOSAyFBoVgmFZsf+fv8JqnwIx/SD6RxY1+Jzz9EWPQcH2v+WgwPP/4qVmjtKw==",
       "license": "MIT",
       "dependencies": {
         "glob": "^7.1.1",
-        "hermes-parser": "0.25.1",
+        "hermes-parser": "0.28.1",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "yargs": "^17.6.2"
@@ -8012,32 +8012,18 @@
       }
     },
     "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
-      "integrity": "sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==",
+      "version": "0.80.1",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.80.1.tgz",
+      "integrity": "sha512-YP12bjz0bzo2lFxZDOPkRJSOkcqAzXCQQIV1wd7lzCTXE0NJNwoaeNBobJvcPhiODEWUYCXPANrZveFhtFu5vw==",
       "license": "MIT"
     },
-    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
-      "integrity": "sha512-EUPM2rfGNO4cbI3olAbhPkIt3q7MapwCwAJBzUfWlZ/pu0PRNOnMQ1IvaXTf3TpeozXV52K1OdprLEI/kI5eUA==",
+    "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.28.1.tgz",
+      "integrity": "sha512-meT17DOuUElMNsL5LZN56d+KBp22hb0EfxWfuPUeoSi54e40v1W4C2V36P75FpsH9fVEfDKpw5Nnkahc8haSsQ==",
       "license": "MIT",
       "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
+        "hermes-parser": "0.28.1"
       }
     },
     "node_modules/react-native/node_modules/brace-expansion": {
@@ -8080,6 +8066,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/react-native/node_modules/hermes-estree": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
+      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-native/node_modules/hermes-parser": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
+      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.28.1"
+      }
+    },
     "node_modules/react-native/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8100,6 +8101,12 @@
       "dependencies": {
         "asap": "~2.0.6"
       }
+    },
+    "node_modules/react-native/node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
     },
     "node_modules/react-native/node_modules/semver": {
       "version": "7.7.2",
@@ -8416,7 +8423,8 @@
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -8497,16 +8505,16 @@
       }
     },
     "node_modules/sentry-expo": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-7.0.1.tgz",
-      "integrity": "sha512-8vmOy4R+qM1peQA9EP8rDGUMBhgMU1D5FyuWY9kfNGatmWuvEmlZpVgaXoXaNPIhPgf2TMrvQIlbqLHtTkoeSA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/sentry-expo/-/sentry-expo-7.2.0.tgz",
+      "integrity": "sha512-stVE2B1RgHxpcup8XU1UIGhoI3cta63guExInl6WYx3d5HsvIu8PZ0yDJnJGflYi9cKPAUCxErIQXMTrS0JQEw==",
       "license": "MIT",
       "dependencies": {
         "@expo/spawn-async": "^1.7.0",
-        "@sentry/integrations": "7.52.1",
-        "@sentry/react": "7.52.1",
-        "@sentry/react-native": "5.5.0",
-        "@sentry/types": "7.52.1",
+        "@sentry/integrations": "7.81.1",
+        "@sentry/react": "7.81.1",
+        "@sentry/react-native": "5.17.0",
+        "@sentry/types": "7.81.1",
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
       },
@@ -8517,90 +8525,16 @@
         "expo-device": "*"
       }
     },
-    "node_modules/sentry-expo/node_modules/@sentry-internal/tracing": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.52.0.tgz",
-      "integrity": "sha512-o1YPcRGtC9tjeFCvWRJsbgK94zpExhzfxWaldAKvi3PuWEmPeewSdO/Q5pBIY1QonvSI+Q3gysLRcVlLYHhO5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.52.0",
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry-internal/tracing/node_modules/@sentry/types": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
-      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry-internal/tracing/node_modules/@sentry/utils": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
-      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/core": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.52.0.tgz",
-      "integrity": "sha512-BWdG6vCMeUeMhF4ILpxXTmw70JJvT1MGJcnv09oSupWHTmqy6I19YP6YcEyFuBL4jXPN51eCl7luIdLGJrPbOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/core/node_modules/@sentry/types": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
-      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/core/node_modules/@sentry/utils": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
-      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/sentry-expo/node_modules/@sentry/react": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.52.1.tgz",
-      "integrity": "sha512-RRH+GJE5TNg5QS86bSjSZuR2snpBTOO5/SU9t4BOqZMknzhMVTClGMm84hffJa9pMPMJPQ2fWQAbhrlD8RcF6w==",
+      "version": "7.81.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.81.1.tgz",
+      "integrity": "sha512-kk0plP/mf8KgVLOiImIpp1liYysmh3Un8uXcVAToomSuHZPGanelFAdP0XhY+0HlWU9KIfxTjhMte1iSwQ8pYw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.52.1",
-        "@sentry/types": "7.52.1",
-        "@sentry/utils": "7.52.1",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
+        "@sentry/browser": "7.81.1",
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1",
+        "hoist-non-react-statics": "^3.3.2"
       },
       "engines": {
         "node": ">=8"
@@ -8610,132 +8544,32 @@
       }
     },
     "node_modules/sentry-expo/node_modules/@sentry/react-native": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.5.0.tgz",
-      "integrity": "sha512-xrES+OAIu3HFhoQSuJjd16Hh02/mByuNoKUjF7e4WDGIiTew3aqlqeLjU7x4npmg5Vbt+ND5jR12u/NmdfArwg==",
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-5.17.0.tgz",
+      "integrity": "sha512-d0TLASMcpUtvw0A8zNznRyCskfH0kwfb3GzqMXXpfPJAG8vsBnY15EFOIc+czOLt6FbV9o3567bHYWhSW51Ssg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "7.52.0",
-        "@sentry/cli": "2.17.5",
-        "@sentry/core": "7.52.0",
-        "@sentry/hub": "7.52.0",
-        "@sentry/integrations": "7.52.0",
-        "@sentry/react": "7.52.0",
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0"
+        "@sentry/browser": "7.81.1",
+        "@sentry/cli": "2.25.2",
+        "@sentry/core": "7.81.1",
+        "@sentry/hub": "7.81.1",
+        "@sentry/integrations": "7.81.1",
+        "@sentry/react": "7.81.1",
+        "@sentry/types": "7.81.1",
+        "@sentry/utils": "7.81.1"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
       },
       "peerDependencies": {
+        "expo": ">=49.0.0",
         "react": ">=17.0.0",
         "react-native": ">=0.65.0"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/browser": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.52.0.tgz",
-      "integrity": "sha512-Sib0T24cQCqqqAhg+nZdfI7qNYGE03jiM3RbY7yG5UoycdnJzWEwrBVSzRTgg3Uya9TRTEGJ+d9vxPIU5TL7TA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.52.0",
-        "@sentry/core": "7.52.0",
-        "@sentry/replay": "7.52.0",
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0",
-        "tslib": "^1.9.3"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/integrations": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.52.0.tgz",
-      "integrity": "sha512-tqxYzgc71XdFD8MTCsVMCPef08lPY9jULE5Zi7TzjyV2AItDRJPkixG0qjwjOGwCtN/6KKz0lGPGYU8ZDxvsbg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0",
-        "localforage": "^1.8.1",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/react": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-7.52.0.tgz",
-      "integrity": "sha512-VQxquyFFlvB81k7UER7tTJxjzbczNI2jqsw6nN1TVDrAIDt8/hT2x7m/M0FlWc88roBKuaMmbvzfNGWaL9abyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/browser": "7.52.0",
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0",
-        "hoist-non-react-statics": "^3.3.2",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "react": "15.x || 16.x || 17.x || 18.x"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/types": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
-      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/react-native/node_modules/@sentry/utils": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
-      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/replay": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.52.0.tgz",
-      "integrity": "sha512-RRPALjDST2s7MHiMcUJ7Wo4WW7EWfUDYSG0LuhMT8DNc+ZsxQoFsLYX/yz8b3f0IUSr7xKBXP+aPeIy3jDAS2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.52.0",
-        "@sentry/types": "7.52.0",
-        "@sentry/utils": "7.52.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/replay/node_modules/@sentry/types": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.52.0.tgz",
-      "integrity": "sha512-XnEWpS6P6UdP1FqbmeqhI96Iowqd2jM5R7zJ97txTdAd5NmdHHH0pODTR9NiQViA1WlsXDut7ZLxgPzC9vIcMA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/sentry-expo/node_modules/@sentry/replay/node_modules/@sentry/utils": {
-      "version": "7.52.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.52.0.tgz",
-      "integrity": "sha512-X1NHYuqW0qpZfP731YcVe+cn36wJdAeBHPYPIkXCl4o4GePCJfH/CM/+9V9cZykNjyLrs2Xy/TavSAHNCj8j7w==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.52.0",
-        "tslib": "^1.9.3"
-      },
-      "engines": {
-        "node": ">=8"
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
       }
     },
     "node_modules/sentry-expo/node_modules/react": {
@@ -8750,12 +8584,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/sentry-expo/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/serialize-error": {
       "version": "2.1.0",
@@ -9428,9 +9256,9 @@
       }
     },
     "node_modules/three": {
-      "version": "0.145.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.145.0.tgz",
-      "integrity": "sha512-EKoHQEtEJ4CB6b2BGMBgLZrfwLjXcSUfoI/MiIXUuRpeYsfK5aPWbYhdtIVWOH+x6X0TouldHKHBuc/LAiFzAw==",
+      "version": "0.166.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.166.1.tgz",
+      "integrity": "sha512-LtuafkKHHzm61AQA1be2MAYIw1IjmhOUxhBa0prrLpEMWbV7ijvxCRHjSgHPGp2493wLBzwKV46tA9nivLEgKg==",
       "license": "MIT"
     },
     "node_modules/throat": {

--- a/package.json
+++ b/package.json
@@ -10,32 +10,32 @@
     "test": "node --test"
   },
   "dependencies": {
-    "expo": "~53.0.11",
+    "expo": "~53.0.17",
     "expo-barcode-scanner": "^13.0.1",
-    "expo-camera": "~16.1.8",
-    "expo-file-system": "~18.1.10",
-    "expo-location": "~18.1.5",
+    "expo-camera": "~16.1.10",
+    "expo-file-system": "~18.1.11",
+    "expo-location": "~18.1.6",
     "expo-media-library": "~17.1.7",
-    "expo-sqlite": "~15.2.12",
+    "expo-sqlite": "~15.2.13",
     "expo-status-bar": "~2.2.3",
     "expo-sensors": "~14.1.4",
     "expo-updates": "~0.28.16",
-    "react": "19.0.0",
-    "react-native": "0.79.5",
-    "react-native-maps": "1.20.1",
+    "react": "19.1.0",
+    "react-native": "0.80.1",
+    "react-native-maps": "1.24.3",
     "react-native-reanimated": "~3.18.0",
-    "react-native-svg": "15.11.2",
-    "three": "^0.145.0",
-    "expo-three": "^7.0.0",
+    "react-native-svg": "15.12.0",
+    "three": "^0.166.1",
+    "expo-three": "^8.0.0",
     "expo-gl": "~15.1.7",
     "suncalc": "^1.9.0",
     "tslib": "^2.8.1",
     "victory": "^37.3.6",
     "victory-native": "^41.17.4",
-    "sentry-expo": "~7.0.0"
+    "sentry-expo": "~7.2.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.0"
+    "@babel/core": "^7.28.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- upgrade Expo and React Native dependencies to their latest versions
- use compatible `three` version required by `expo-three`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868df8094d483329ce487b14f4df312