### PR TITLE
Simplify app to single menu

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,21 +1,10 @@
-import React, { useState } from 'react';
-import { ScrollView, View, Text, Button, ErrorUtils } from 'react-native';
+import React from 'react';
+import { View, Text, Button, ErrorUtils } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
 // Components
-import GPSStatus from './src/components/GPSStatus';
-import SampleForm from './src/components/SampleForm';
-import SurveyForm from './src/components/SurveyForm';
-import DataExport from './src/components/DataExport';
-import SunTracker3D from './src/components/SunTracker3D';
-import CameraCapture from './src/components/CameraCapture';
 import ErrorBoundary from './components/ErrorBoundary';
 import * as Sentry from 'sentry-expo';
-
-// Hooks
-import useLocation from './src/hooks/useLocation';
-import useSamples from './src/hooks/useSamples';
-import useSurveys from './src/hooks/useSurveys';
 
 // Styles
 import { styles } from './src/styles/AppStyles';
@@ -57,135 +46,26 @@ if (ErrorUtils.setGlobalHandler) {
 }
 
 export default function App() {
-  // UI State
-  const [showSampleForm, setShowSampleForm] = useState(false);
-  const [showSurveyForm, setShowSurveyForm] = useState(false);
-  const [showCamera, setShowCamera] = useState(false);
-
-  // Custom Hooks
-  const {
-    location,
-    watchingPosition,
-    toggleWatching
-  } = useLocation();
-  const { samples, addSample } = useSamples();
-  const { surveys, addSurvey } = useSurveys();
-
-  // Event Handlers
-  const handleSampleSave = (sampleData) => {
-    addSample(sampleData, location);
-    setShowSampleForm(false);
-  };
-
-  const handleSurveySave = (surveyData) => {
-    addSurvey(surveyData, location);
-    setShowSurveyForm(false);
-  };
-
   return (
     <ErrorBoundary logToFile>
-      <ScrollView style={styles.container}>
-      <StatusBar style="auto" />
-      
-      <Text style={styles.title}>Hydrographer's Companion</Text>
-      
-      {/* GPS Status Component with Live Compass */}
-      <GPSStatus
-        location={location}
-        watchingPosition={watchingPosition}
-        toggleWatching={toggleWatching}
-      />
-
-      {/* 3D Sun Tracker */}
-      <SunTracker3D />
-
-      {/* Operations Panel */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Field Operations</Text>
-        <View style={styles.buttonGrid}>
-          <View style={styles.buttonQuarter}>
-            <Button
-              title="Cross-Section"
-              onPress={() => setShowSurveyForm(true)}
-            />
+      <View style={styles.menuContainer}>
+        <StatusBar style="auto" />
+        <Text style={styles.menuTitle}>HydCom</Text>
+        <View style={styles.menuButtons}>
+          <View style={styles.menuButton}>
+            <Button title="Location" onPress={() => {}} />
           </View>
-          <View style={styles.buttonQuarter}>
-            <Button
-              title="New Sample"
-              onPress={() => setShowSampleForm(true)}
-            />
+          <View style={styles.menuButton}>
+            <Button title="Surveying" onPress={() => {}} />
           </View>
-          <View style={styles.buttonQuarter}>
-            <Button
-              title="Camera"
-              onPress={() => setShowCamera(true)}
-            />
+          <View style={styles.menuButton}>
+            <Button title="Sampling" onPress={() => {}} />
+          </View>
+          <View style={styles.menuButton}>
+            <Button title="Camera" onPress={() => {}} />
           </View>
         </View>
       </View>
-
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Export & Backup</Text>
-        <DataExport samples={samples} surveys={surveys} />
-      </View>
-
-      {/* Recent Data Summary */}
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Recent Samples ({samples.length})</Text>
-        {samples.slice(-3).map((sample, index) => (
-          <View key={index} style={styles.dataItem}>
-            <Text style={styles.dataId}>{sample.id}</Text>
-            <Text style={styles.dataDetails}>{sample.timestamp}</Text>
-            <Text style={styles.dataDetails}>
-              {sample.latitude.toFixed(6)}, {sample.longitude.toFixed(6)}
-            </Text>
-          </View>
-        ))}
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Recent Surveys ({surveys.length})</Text>
-        {surveys.slice(-3).map((survey, index) => (
-          <View key={index} style={styles.dataItem}>
-            <Text style={styles.dataId}>{survey.id}</Text>
-            <Text style={styles.dataDetails}>{survey.timestamp}</Text>
-            <Text style={styles.dataDetails}>
-              {survey.points.length} points, {survey.changePoints.length} change points
-            </Text>
-            <Text style={styles.dataDetails}>
-              Width: {survey.width.toFixed(1)}m, Max Depth: {survey.maxDepth.toFixed(1)}m
-            </Text>
-            {survey.misclose !== null && (
-              <Text style={[styles.dataDetails, { 
-                color: survey.misclose <= survey.miscloseTolerance ? '#28a745' : '#dc3545' 
-              }]}>
-                Misclose: {(survey.misclose * 1000).toFixed(1)}mm
-              </Text>
-            )}
-          </View>
-        ))}
-      </View>
-
-      {/* Modals */}
-      <SampleForm
-        visible={showSampleForm}
-        onClose={() => setShowSampleForm(false)}
-        onSave={handleSampleSave}
-        location={location}
-      />
-
-      <SurveyForm
-        visible={showSurveyForm}
-        onClose={() => setShowSurveyForm(false)}
-        onSave={handleSurveySave}
-        location={location}
-      />
-
-      <CameraCapture
-        visible={showCamera}
-        onClose={() => setShowCamera(false)}
-      />
-    </ScrollView>
     </ErrorBoundary>
   );
 }

--- a/src/styles/AppStyles.js
+++ b/src/styles/AppStyles.js
@@ -17,6 +17,31 @@ export const styles = StyleSheet.create({
     marginBottom: 20,
     color: '#333',
   },
+
+  // Main Menu Styles
+  menuContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+    backgroundColor: '#f5f5f5',
+  },
+
+  menuTitle: {
+    fontSize: 32,
+    fontWeight: 'bold',
+    marginBottom: 40,
+    color: '#333',
+    textAlign: 'center',
+  },
+
+  menuButtons: {
+    width: '80%',
+  },
+
+  menuButton: {
+    marginVertical: 10,
+  },
   
   // Section Styles
   section: {


### PR DESCRIPTION
## Summary
- simplify `App.js` to render only a main menu screen
- add styles for the new menu layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb308ed6483328abffabc09809e1e