### PR TITLE
Fix Hermes bundling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "expo-status-bar": "~2.2.3",
         "expo-three": "^8.0.0",
         "expo-updates": "~0.28.16",
+        "hermes-engine": "0.11.0",
         "react": "19.1.0",
         "react-native": "0.80.1",
         "react-native-maps": "1.24.3",
@@ -5532,6 +5533,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hermes-engine": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/hermes-engine/-/hermes-engine-0.11.0.tgz",
+      "integrity": "sha512-7aMUlZja2IyLYAcZ69NBnwJAR5ZOYlSllj0oMpx08a8HzxHOys0eKCzfphrf6D0vX1JGO1QQvVsQKe6TkYherw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "victory": "^37.3.6",
     "victory-native": "^41.17.4",
     "sentry-expo": "~7.2.0",
-    "crypto-js": "^4.2.0"
+    "crypto-js": "^4.2.0",
+    "hermes-engine": "0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0"


### PR DESCRIPTION
## Summary
- add `hermes-engine` so Expo can find `hermes` compiler during bundling

## Testing
- `npm test`
- `npx expo export --output-dir dist --dump-sourcemap --dump-assetmap --platform ios --platform android`


------
https://chatgpt.com/codex/tasks/task_e_686bb5d5669483328ab8edece7c10545