### PR TITLE
Fix react alias for Metro

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ If the camera view shows a blank screen even after granting permissions:
    ```
 
 3. Force quit and reopen the Expo Go app on your device.
+
+### Resolving duplicate React with sentry-expo
+If Metro fails to resolve `./cjs/react.development.js` from `sentry-expo`, the bundler is picking up Sentry's internal copy of React. We provide a `metro.config.js` that aliases `react` to the project's own version. Ensure this file is in the project root and restart `expo start` after running `npm install`.
+

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,11 @@
+const { getDefaultConfig } = require('@expo/metro-config');
+const path = require('path');
+
+const config = getDefaultConfig(__dirname);
+
+// Force metro to resolve react from the project root
+config.resolver.extraNodeModules = {
+  react: path.resolve(__dirname, 'node_modules/react'),
+};
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- add `metro.config.js` to force Metro to use the project's React
- document resolving duplicate React issue in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bc02e0e6c8332b06311f4c701eada