### PR TITLE
Fix React Native version mismatch notes

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -17,6 +17,14 @@ jobs:
       - name: Install dependencies
         run: npm ci || npm install
 
+      - name: Install watchman
+        run: sudo apt-get update && sudo apt-get install -y watchman
+
+      - name: Clear Metro and watchman caches
+        run: |
+          watchman watch-del-all
+          timeout 10s npx expo start --clear || true
+
       - name: Install expo-cli and eas-cli
         run: npm install -g expo-cli@6.3.10 eas-cli@16.13.4
 

--- a/README.md
+++ b/README.md
@@ -47,3 +47,20 @@ If the camera view shows a blank screen even after granting permissions:
 
 3. Force quit and reopen the Expo Go app on your device.
 
+## React Native Version Mismatch
+
+If you see a "React Native version mismatch" error (for example, JavaScript
+version `0.80.1` while the native runtime reports `0.79.2`), your installed
+Expo Go app is likely out of date. Make sure the version of Expo Go on your
+device matches the SDK version declared in `package.json` (`expo` `53.x`).
+
+1. Update Expo Go from the App Store or Play Store.
+2. Restart the development server with a cleared cache:
+
+   ```bash
+   watchman watch-del-all && npx expo start --clear
+   ```
+
+This ensures the JavaScript bundle uses the same React Native version as the
+native runtime.
+


### PR DESCRIPTION
## Summary
- document fix for React Native version mismatch error
- add cache clearing to EAS workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c9ccd5230833291369a3a6498994a