### PR TITLE
Fix EAS update workflow ordering

### DIFF
--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -19,7 +21,10 @@ jobs:
       - name: Install expo and eas
         run: npm install -g expo-cli eas-cli
 
-      - name: Configure EAS project 
+      - name: Log in to Expo
+        run: eas login --token "$EXPO_TOKEN"
+
+      - name: Configure EAS project
         run: eas init
 
       - name: Publish to Expo


### PR DESCRIPTION
## Summary
- log in to Expo before running `eas init`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cff0cdb748332a399666c6bc5ddf5